### PR TITLE
Changed foreground color of invalid scope

### DIFF
--- a/WebDeveloperBright.tmTheme
+++ b/WebDeveloperBright.tmTheme
@@ -132,7 +132,7 @@
 				<key>background</key>
 				<string>#00A8C6</string>
 				<key>foreground</key>
-				<string>#F8F8F0</string>
+				<string>#999999</string>
 			</dict>
 		</dict>
 


### PR DESCRIPTION
Made the color darker from #F8F8F0 to #999999. The reason is that when `highlight_line` is set to `true` the text can't be read while you are typing it. I've seen the issue on JSON files.

**Before**
![before](https://f.cloud.github.com/assets/61048/905894/d02203a6-fc5a-11e2-8814-6a0f143f1e65.png)

**After**
![after](https://f.cloud.github.com/assets/61048/905895/d47d96cc-fc5a-11e2-9bf3-b3109ce8d4db.png)
